### PR TITLE
LTJ-129 Add JWT validation for internal API with RBAC tests and access denied handler

### DIFF
--- a/backend/src/main/java/com/uth/datalabeling/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/uth/datalabeling/common/exception/GlobalExceptionHandler.java
@@ -19,9 +19,26 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
   }
 
+  // Ưu tiên bắt các ngoại lệ liên quan đến phân quyền của Spring Security
+  // Nếu không có block này thì Exception catch-all sẽ báo lỗi 500 Server Error
+  @ExceptionHandler(value = {
+      org.springframework.security.access.AccessDeniedException.class,
+      org.springframework.security.authorization.AuthorizationDeniedException.class
+  })
+  public void handleAccessDeniedException(Exception ex) throws Exception {
+    // Throw ngược ra ngoài để Spring Security can thiệp
+    // Và gọi JwtAccessDeniedHandler (trả về lỗi 403 Forbidden)
+    throw ex;
+  }
+
   @ExceptionHandler(value = MethodArgumentNotValidException.class)
   public ResponseEntity<ApiResponse<Object>> handleValidationException(MethodArgumentNotValidException exception) {
     String messageKey = exception.getFieldError().getDefaultMessage();
+    String field = exception.getFieldError().getField();
+
+    // Ghi log để biết field nào bị thiếu/lỗi validation ở môi trường test/dev
+    System.out.println("\nValidation failed for field: " + field + ", messageKey: " + messageKey);
+
     // Mặc định errorCode sẽ là VALIDATION_ERROR
     // Để đề phòng trường hợp ghi sai enumKey ở các message validation
     ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;

--- a/backend/src/main/java/com/uth/datalabeling/config/SecurityConfig.java
+++ b/backend/src/main/java/com/uth/datalabeling/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,14 +26,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
   private final String[] PUBLIC_ENDPOINTS = {
       "/auth/login",
       "/v3/api-docs/**",
       "/swagger-ui/**",
-      "/swagger-ui.html",
-      "/users/**"
+      "/swagger-ui.html"
   };
 
   @Bean

--- a/backend/src/main/java/com/uth/datalabeling/modules/iam/controller/UserController.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/iam/controller/UserController.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.UUID;
 @RequestMapping("/users")
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@PreAuthorize("hasRole('ADMIN')")
 public class UserController {
   UserService userService;
 

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,9 +6,9 @@
       "description": "Signing secret for JWT (HS256)."
     },
     {
-      "name": "jwt.expiration-ms",
+      "name": "jwt.expiration",
       "type": "java.lang.Long",
-      "description": "JWT expiration time in milliseconds."
+      "description": "JWT expiration time in seconds."
     },
     {
       "name": "jwt.issuer",

--- a/backend/src/test/java/com/uth/datalabeling/modules/iam/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/uth/datalabeling/modules/iam/controller/UserControllerTest.java
@@ -1,0 +1,174 @@
+package com.uth.datalabeling.modules.iam.controller;
+
+import com.uth.datalabeling.config.SecurityConfig;
+import com.uth.datalabeling.modules.iam.dto.request.UserCreationRequest;
+import com.uth.datalabeling.modules.iam.dto.request.UserUpdateRequest;
+import com.uth.datalabeling.modules.iam.dto.response.UserResponse;
+import com.uth.datalabeling.modules.iam.repository.UserRepository;
+import com.uth.datalabeling.modules.iam.service.UserService;
+import com.uth.datalabeling.security.jwt.JwtAccessDeniedHandler;
+import com.uth.datalabeling.security.jwt.JwtAuthenticationEntryPoint;
+import com.uth.datalabeling.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class, JwtAccessDeniedHandler.class})
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    // Security config dependencies
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserDetailsService userDetailsService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    private UUID userId;
+    private String validCreationJson;
+    private String validUpdateJson;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+
+        validCreationJson = """
+                {
+                    "email": "test@example.com",
+                    "full_name": "Test Admin",
+                    "password": "Password123",
+                    "role": "ADMIN",
+                    "active": true
+                }
+                """;
+
+        validUpdateJson = """
+                {
+                    "email": "test-updated@example.com",
+                    "full_name": "Test Admin Updated",
+                    "password": "Password123new",
+                    "role": "ADMIN",
+                    "active": true
+                }
+                """;
+
+        UserResponse mockResponse = UserResponse.builder()
+                .id(userId)
+                .email("test@example.com")
+                .fullName("Test Admin")
+                .role("ADMIN")
+                .active(true)
+                .build();
+
+        Mockito.when(userService.createUser(any(UserCreationRequest.class))).thenReturn(mockResponse);
+        Mockito.when(userService.getAllUsers()).thenReturn(List.of(mockResponse));
+        Mockito.when(userService.getUserById(userId)).thenReturn(mockResponse);
+        Mockito.when(userService.updateUser(eq(userId), any(UserUpdateRequest.class))).thenReturn(mockResponse);
+        Mockito.doNothing().when(userService).deleteUser(userId);
+    }
+
+    // --- POSITIVE TESTS (ROLE = ADMIN) ---
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createUser_WithAdminRole_ReturnsCreated() throws Exception {
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validCreationJson))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.result.email").value("test@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getAllUsers_WithAdminRole_ReturnsList() throws Exception {
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].email").value("test@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getUser_WithAdminRole_ReturnsUser() throws Exception {
+        mockMvc.perform(get("/users/" + userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.email").value("test@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void updateUser_WithAdminRole_ReturnsUser() throws Exception {
+        mockMvc.perform(put("/users/" + userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validUpdateJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.email").value("test@example.com"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteUser_WithAdminRole_ReturnsNoContent() throws Exception {
+        mockMvc.perform(delete("/users/" + userId))
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.message").value("User has been deleted"));
+    }
+
+    // --- NEGATIVE TESTS (ROLE = ANNOTATOR) ---
+
+    @Test
+    @WithMockUser(roles = "ANNOTATOR")
+    void getAllUsers_WithAnnotatorRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ANNOTATOR")
+    void createUser_WithAnnotatorRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validCreationJson))
+                .andExpect(status().isForbidden());
+    }
+
+    // --- UNAUTHENTICATED TESTS ---
+
+    @Test
+    void getAllUsers_WithoutAuth_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createUser_WithoutAuth_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validCreationJson))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
Implement JWT validation for internal API endpoints and improve security handling.

## Changes
- Add JWT validation for internal API requests
- Implement custom AccessDeniedHandler for Spring Security
- Add RBAC unit tests for UserController

## Testing
- Verified JWT validation with internal API requests
- Added unit tests for RBAC scenarios

## Jira
[LTJ-129](https://ntdchuong.atlassian.net/browse/LTJ-129)

[LTJ-129]: https://ntdchuong.atlassian.net/browse/LTJ-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ