### PR TITLE
Enhance system configuration with mapper, JSON fields, and transaction mode

### DIFF
--- a/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/dto/request/SystemConfigurationUpdateRequest.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/dto/request/SystemConfigurationUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.uth.datalabeling.modules.systemconfig.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
@@ -19,19 +20,23 @@ import lombok.experimental.FieldDefaults;
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class SystemConfigurationUpdateRequest {
+  @JsonProperty("max_image_file_size_mb")
   @NotNull(message = "MISSING_REQUIRED_FIELD")
   @Min(value = 1, message = "INVALID_MAX_IMAGE_FILE_SIZE")
   @Max(value = 100, message = "INVALID_MAX_IMAGE_FILE_SIZE")
   Integer maxImageFileSizeMb;
 
+  @JsonProperty("ai_labeling_enabled")
   @NotNull(message = "MISSING_REQUIRED_FIELD")
   Boolean aiLabelingEnabled; // Tính năng hỗ trợ gắn nhãn AI
 
+  @JsonProperty("default_page_size")
   @NotNull(message = "MISSING_REQUIRED_FIELD")
   @Min(value = 5, message = "INVALID_DEFAULT_PAGE_SIZE")
   @Max(value = 200, message = "INVALID_DEFAULT_PAGE_SIZE")
   Integer defaultPageSize;
 
+  @JsonProperty("allowed_image_extensions")
   @NotEmpty(message = "MISSING_REQUIRED_FIELD")
   @Size(min = 1, max = 10, message = "INVALID_ALLOWED_IMAGE_EXTENSIONS")
   List<String> allowedImageExtensions;

--- a/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/dto/response/SystemConfigurationResponse.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/dto/response/SystemConfigurationResponse.java
@@ -1,5 +1,6 @@
 package com.uth.datalabeling.modules.systemconfig.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -15,10 +16,21 @@ import lombok.experimental.FieldDefaults;
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class SystemConfigurationResponse {
+  @JsonProperty("max_image_file_size_mb")
   Integer maxImageFileSizeMb;
+
+  @JsonProperty("ai_labeling_enabled")
   boolean aiLabelingEnabled;
+
+  @JsonProperty("default_page_size")
   Integer defaultPageSize;
+
+  @JsonProperty("allowed_image_extensions")
   List<String> allowedImageExtensions;
+
+  @JsonProperty("updated_by")
   String updatedBy;
+
+  @JsonProperty("updated_at")
   LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/entity/SystemConfiguration.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/entity/SystemConfiguration.java
@@ -50,5 +50,7 @@ public class SystemConfiguration {
   String updatedBy;
 
   @Version
-  Long version;
+  @Column(nullable = false)
+  @Builder.Default
+  Long version = 0L;
 }

--- a/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/mapper/SystemConfigurationMapper.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/mapper/SystemConfigurationMapper.java
@@ -1,0 +1,52 @@
+package com.uth.datalabeling.modules.systemconfig.mapper;
+
+import com.uth.datalabeling.modules.systemconfig.dto.request.SystemConfigurationUpdateRequest;
+import com.uth.datalabeling.modules.systemconfig.dto.response.SystemConfigurationResponse;
+import com.uth.datalabeling.modules.systemconfig.entity.SystemConfiguration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+@Mapper(componentModel = "spring", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+public interface SystemConfigurationMapper {
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "updatedBy", ignore = true)
+  @Mapping(target = "version", ignore = true)
+  @Mapping(target = "allowedImageExtensions", source = "allowedImageExtensions", qualifiedByName = "joinExtensions")
+  void updateEntity(@MappingTarget SystemConfiguration entity, SystemConfigurationUpdateRequest request);
+
+  @Mapping(target = "allowedImageExtensions", source = "allowedImageExtensions", qualifiedByName = "splitExtensions")
+  SystemConfigurationResponse toResponse(SystemConfiguration entity);
+
+  @Named("joinExtensions")
+  default String joinExtensions(List<String> extensions) {
+    if (extensions == null) {
+      return null;
+    }
+    return extensions.stream()
+        .map(ext -> ext == null ? "" : ext.trim().toLowerCase(Locale.ROOT))
+        .filter(ext -> !ext.isEmpty())
+        .distinct()
+        .collect(Collectors.joining(","));
+  }
+
+  @Named("splitExtensions")
+  default List<String> splitExtensions(String extensions) {
+    if (extensions == null || extensions.isEmpty()) {
+      return List.of();
+    }
+    return Arrays.stream(extensions.split(","))
+        .map(String::trim)
+        .filter(ext -> !ext.isEmpty())
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/service/SystemConfigurationService.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/service/SystemConfigurationService.java
@@ -5,15 +5,14 @@ import com.uth.datalabeling.common.exception.ErrorCode;
 import com.uth.datalabeling.modules.systemconfig.dto.request.SystemConfigurationUpdateRequest;
 import com.uth.datalabeling.modules.systemconfig.dto.response.SystemConfigurationResponse;
 import com.uth.datalabeling.modules.systemconfig.entity.SystemConfiguration;
+import com.uth.datalabeling.modules.systemconfig.mapper.SystemConfigurationMapper;
 import com.uth.datalabeling.modules.systemconfig.repository.SystemConfigurationRepository;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,22 +24,23 @@ public class SystemConfigurationService {
   static final String DEFAULT_IMAGE_EXTENSIONS = "jpg,jpeg,png,webp";
 
   SystemConfigurationRepository systemConfigurationRepository;
+  SystemConfigurationMapper systemConfigurationMapper;
 
+  @Transactional(readOnly = true)
   public SystemConfigurationResponse getConfiguration() {
-    return toResponse(getOrCreateSingleton());
+    return systemConfigurationMapper.toResponse(getOrCreateSingleton());
   }
 
+  @Transactional
   public SystemConfigurationResponse updateConfiguration(SystemConfigurationUpdateRequest request,
       String updatedBy) {
-    SystemConfiguration config = getOrCreateSingleton();
+    validateExtensions(request.getAllowedImageExtensions());
 
-    config.setMaxImageFileSizeMb(request.getMaxImageFileSizeMb());
-    config.setAiLabelingEnabled(Boolean.TRUE.equals(request.getAiLabelingEnabled()));
-    config.setDefaultPageSize(request.getDefaultPageSize());
-    config.setAllowedImageExtensions(joinExtensions(request.getAllowedImageExtensions()));
+    SystemConfiguration config = getOrCreateSingleton();
+    systemConfigurationMapper.updateEntity(config, request);
     config.setUpdatedBy(updatedBy);
 
-    return toResponse(systemConfigurationRepository.save(config));
+    return systemConfigurationMapper.toResponse(systemConfigurationRepository.save(config));
   }
 
   private SystemConfiguration getOrCreateSingleton() {
@@ -56,39 +56,18 @@ public class SystemConfigurationService {
         .defaultPageSize(DEFAULT_PAGE_SIZE)
         .allowedImageExtensions(DEFAULT_IMAGE_EXTENSIONS)
         .updatedBy("system")
+        .version(0L)
         .build();
   }
 
-  private SystemConfigurationResponse toResponse(SystemConfiguration entity) {
-    return SystemConfigurationResponse.builder()
-        .maxImageFileSizeMb(entity.getMaxImageFileSizeMb())
-        .aiLabelingEnabled(entity.isAiLabelingEnabled())
-        .defaultPageSize(entity.getDefaultPageSize())
-        .allowedImageExtensions(splitExtensions(entity.getAllowedImageExtensions()))
-        .updatedBy(entity.getUpdatedBy())
-        .updatedAt(entity.getUpdatedAt())
-        .build();
-  }
-
-  private String joinExtensions(List<String> extensions) {
-    return extensions.stream()
-        .map(ext -> normalizeExtension(ext))
-        .distinct()
-        .collect(Collectors.joining(","));
-  }
-
-  private String normalizeExtension(String extension) {
-    String normalized = extension == null ? "" : extension.trim().toLowerCase(Locale.ROOT);
-    if (!normalized.matches("^[a-z0-9]+$")) {
-      throw new AppException(ErrorCode.INVALID_IMAGE_EXTENSION);
+  private void validateExtensions(java.util.List<String> extensions) {
+    if (extensions != null) {
+      for (String ext : extensions) {
+        String normalized = ext == null ? "" : ext.trim().toLowerCase(Locale.ROOT);
+        if (!normalized.matches("^[a-z0-9]+$")) {
+          throw new AppException(ErrorCode.INVALID_IMAGE_EXTENSION);
+        }
+      }
     }
-    return normalized;
-  }
-
-  private List<String> splitExtensions(String extensions) {
-    return Arrays.stream(extensions.split(","))
-        .map(String::trim)
-        .filter(ext -> !ext.isBlank())
-        .toList();
   }
 }

--- a/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/service/SystemConfigurationService.java
+++ b/backend/src/main/java/com/uth/datalabeling/modules/systemconfig/service/SystemConfigurationService.java
@@ -26,7 +26,7 @@ public class SystemConfigurationService {
   SystemConfigurationRepository systemConfigurationRepository;
   SystemConfigurationMapper systemConfigurationMapper;
 
-  @Transactional(readOnly = true)
+  @Transactional
   public SystemConfigurationResponse getConfiguration() {
     return systemConfigurationMapper.toResponse(getOrCreateSingleton());
   }

--- a/backend/src/main/resources/db/migration/V3__Fix_system_configuration_version_not_null.sql
+++ b/backend/src/main/resources/db/migration/V3__Fix_system_configuration_version_not_null.sql
@@ -1,0 +1,12 @@
+-- Ensure optimistic locking version is always non-null for system_configuration
+-- This prevents Hibernate @Version increment failures when legacy data contains NULL version.
+
+UPDATE system_configuration
+SET version = 0
+WHERE version IS NULL;
+
+ALTER TABLE system_configuration
+ALTER COLUMN version SET DEFAULT 0;
+
+ALTER TABLE system_configuration
+ALTER COLUMN version SET NOT NULL;


### PR DESCRIPTION
Fixes system config update failures caused by null optimistic-lock version and standardizes mapping flow.

## Changes
- Add SystemConfigurationMapper (MapStruct) for entity/DTO conversion.
- Add @JsonProperty for system config request/response fields (snake_case compatibility).
- Refactor SystemConfigurationService to use mapper-based update flow.
- Set default version = 0L in entity for optimistic locking.
- Add Flyway migration V3__Fix_system_configuration_version_not_null.sql:
  + backfill version from NULL to 0
  + set default version = 0
  + enforce version NOT NULL

## Validation:
- Backend compile passed.
- System config controller tests passed (6/6).