### PR TITLE
LTJ-106: implement reviewer reject functionality with error categories a…

### DIFF
--- a/frontend/src/components/reviewer/RejectModal.jsx
+++ b/frontend/src/components/reviewer/RejectModal.jsx
@@ -28,8 +28,15 @@ export default function RejectModal({ onClose, onConfirm }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    // No logic needed for this task, just close the modal
-    onClose();
+    if (selectedCategories.length === 0) {
+      setError('Please select at least one error category.');
+      return;
+    }
+    
+    onConfirm({
+      categories: selectedCategories,
+      note: note.trim()
+    });
   };
 
   return (

--- a/frontend/src/pages/reviewer/ReviewWorkspace.jsx
+++ b/frontend/src/pages/reviewer/ReviewWorkspace.jsx
@@ -30,6 +30,7 @@ export default function ReviewWorkspace() {
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showApproveModal, setShowApproveModal] = useState(false);
+  const [showRejectModal, setShowRejectModal] = useState(false);
   
   const review = MOCK_REVIEW_DETAIL; // In real app, fetch by id
 
@@ -47,6 +48,18 @@ export default function ReviewWorkspace() {
     console.log('Approved task', id);
     // In real app: await api.updateTaskStatus(id, 'Completed');
     setShowApproveModal(false);
+    navigate('/reviewer'); // Go back to list
+  };
+
+  const handleReject = () => {
+    setShowRejectModal(true);
+  };
+
+  const handleConfirmReject = (rejectionData) => {
+    // Simulate API call to update status to Rejected with metadata
+    console.log('Rejected task', id, rejectionData);
+    // In real app: await api.rejectTask(id, rejectionData);
+    setShowRejectModal(false);
     navigate('/reviewer'); // Go back to list
   };
 
@@ -168,6 +181,10 @@ export default function ReviewWorkspace() {
                   <Check size={18} style={{ marginRight: '8px' }} />
                   Approve
                 </button>
+                <button className="btn btn--danger btn--full" onClick={handleReject}>
+                  <X size={18} style={{ marginRight: '8px' }} />
+                  Reject
+                </button>
               </div>
             </div>
           </div>
@@ -186,6 +203,14 @@ export default function ReviewWorkspace() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Reject Modal */}
+      {showRejectModal && (
+        <RejectModal 
+          onClose={() => setShowRejectModal(false)} 
+          onConfirm={handleConfirmReject} 
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Giao diện: Thêm nút "Từ chối" (Reject) vào bảng điều khiển Reviewer Workspace với phong cách đồng nhất.
Form xác nhận: Tích hợp Modal thông minh cho phép Reviewer chọn một hoặc nhiều danh mục lỗi từ danh sách có sẵn (như Sai nhãn, Bounding box không chính xác, Thiếu đối tượng...).
Ghi chú chi tiết: Thêm khu vực nhập phản hồi chi tiết với bộ đếm ký tự (tối đa 500 ký tự) để Annotator hiểu rõ lý do bị từ chối.
Logic kiểm soát: Thêm kiểm tra ràng buộc để đảm bảo Reviewer phải chọn ít nhất một lý do lỗi trước khi có thể xác nhận từ chối.
Tích hợp: Toàn bộ logic thu thập dữ liệu đã được sẵn sàng để kết nối với API Backend trong tương lai.